### PR TITLE
Correct Missing Titles for Units and Quantities, add Support for Array Quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 
 ## [0.30] — 2024-04-16
 
-### TODO ###
 ### Security
 ### Added
+SliceQuantity and Unit Type-specific quantities to hold array of vector data with an associated unit.
 ### Changed
 Correcting bug in utoipa derive for `Units`.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 ### Fixed
 -->
 
+## [0.30] — 2024-04-16
+
+### TODO ###
+### Security
+### Added
+### Changed
+Correcting bug in utoipa derive for `Units`.
+### Deprecated
+### Removed
+
+
 ## [0.2.5] — 2024-04-16
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_units"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 keywords =  ["units", "measurement", "SI", "dimensional-analysis"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An example of including all units and serialization support:
 
 ```toml
 [dependencies]
-runtime_units = { version = "0.2.5", features = ["All", "serde"] }
+runtime_units = { version = "0.3.0", features = ["All", "serde"] }
 ```
 no_std is supported if the `std` feature flag is removed.
 
@@ -17,9 +17,10 @@ Individual unit types are supported as features, allowing you to pare down the l
 
 ## Quantities and Units
 
-This library consists of two sets of data structures:
+This library consists of three sets of data structures:
 1. Unit data structures. These store data regarding unit itself, and the storage of the unit definition itself (e.g. the dimensions of the unit, and the conversion factor to convert a given unit to its base quantity). These can be serialized (if serde is enabled), and converted to a utoipa schema (if the utoipa feature flag is enabled). 
-2. Quantity data structures. These store a scalar value and an associated unit. Also serializable like the units, and most math operations can be performed on them directly (e.g. scalar Mul/Div, multipliying quantites by each other, equality operators).
+2. Scalar Quantity data structures. These store a scalar value and an associated unit. Also serializable like the units, and most math operations can be performed on them directly (e.g. scalar Mul/Div, multipliying quantites by each other, equality operators).
+3. Array Quantity data structures. These store an array and an associated unit. Analogous to (2). 
 
 # More details:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ use quantity::Quantity;
 
 
 pub mod errors;
+pub mod slice_quantity;
 pub(crate) mod quantity;
 pub(crate) mod macros;
 pub mod units_base;
+pub mod traits;
 mod unit_definitions;
 pub use crate::unit_definitions::*;
 mod tests;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -220,7 +220,7 @@ macro_rules! quantity {
         }
     ) => {
         #[cfg(feature="utoipa")]
-        use utoipa::ToSchema;
+        use utoipa::{ToSchema, schema};
         use $crate::errors::RuntimeUnitError;
         use $crate::Quantity;
         use $crate::units_base::{UnitDefinition, UnitBase};
@@ -552,7 +552,7 @@ macro_rules! system {
         use $crate::Quantity;
         use $crate::units::*;
         #[cfg(feature="utoipa")]
-        use utoipa::ToSchema;
+        use utoipa::{ToSchema, schema};
         use paste::paste;
         paste::paste!{$(            
            paste::paste!{#[cfg(any(feature = "" $quantity, feature="All"))]
@@ -648,6 +648,7 @@ macro_rules! system {
             {
                 $(
                     #[cfg(any(feature = "" $quantity, feature="All"))]   
+                    #[cfg_attr(feature="utoipa", schema(title = "" $quantity))]
                     $quantity($quantity),
                 )+
             }
@@ -659,7 +660,7 @@ macro_rules! system {
                     match self
                     {
                         $(
-                            #[cfg(any(feature = "" $quantity, feature="All"))]   
+                            #[cfg(any(feature = "" $quantity, feature="All"))]                               
                             Quantities::$quantity(x)=> $crate::Units::from(x.unit),
                         )+
                     }
@@ -750,7 +751,8 @@ macro_rules! system {
                 pub enum Units
                 {                               
                     $(
-                        #[cfg(any(feature = "" $quantity, feature="All"))]                 
+                        #[cfg(any(feature = "" $quantity, feature="All"))]    
+                        #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity Unit>]))]                                                     
                         $quantity([<$quantity Unit>]),
                     )+                
                 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,22 +35,122 @@ macro_rules! prefix {
     (kibi) => { 1024.0 };
 }
 #[macro_export]
+macro_rules! impl_quantity_slice {
+    ($quantity:ident) =>
+    {
+        paste::paste!
+        {
+        use $crate::traits::Slice;       
+
+        use core::ops::{Mul, Div, Add, Sub, AddAssign, SubAssign, MulAssign, DivAssign };
+        impl<T: Clone+Slice<f64>> Div<f64> for [<$quantity Slice>]<T>
+        {
+            type Output = [<$quantity Slice>]<T>;
+
+            fn div(self, rhs: f64) -> Self::Output {
+                let mut result = self.clone();
+                for val in result.values.as_mut_slice()
+                {  
+                *val /= rhs;
+                }
+                result
+            }
+        }
+
+
+        impl<T: Clone+Slice<f64>> Mul<f64> for [<$quantity Slice>]<T>
+        {
+            type Output = [<$quantity Slice>]<T>;
+
+            fn mul(self, rhs: f64) -> Self::Output {
+                let mut result = self.clone();
+                for val in result.values.as_mut_slice()
+                {  
+                *val *= rhs;
+                }
+                result
+            }
+        }
+        impl<T: Clone+Slice<f64>> DivAssign<f64> for [<$quantity Slice>]<T>
+        {
+
+            fn div_assign(&mut self, rhs: f64) {        
+                for val in self.values.as_mut_slice()
+                {  
+                *val /= rhs;
+                }
+            }
+        }
+        impl<T: Clone+Slice<f64>> MulAssign<f64> for [<$quantity Slice>]<T>
+        {
+
+            fn mul_assign(&mut self, rhs: f64) {        
+                for val in self.values.as_mut_slice()
+                {  
+                *val *= rhs;
+                }
+            }
+        }
+        use $crate::traits::Unit;
+        impl<T: Clone+Slice<f64>> AddAssign<[<$quantity Slice>]<T>> for [<$quantity Slice>]<T>
+        {
+
+            fn add_assign(&mut self, rhs: [<$quantity Slice>]<T>) {            
+                if rhs.values.len() != self.values.len()
+                {
+                    panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+                }
+                let factor = rhs.unit.definition().convert_unchecked(self.unit.definition()).multiplier;
+                for (val, &rhs) in self.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+                {  
+                *val += rhs*factor;
+                }
+            }
+        }
+        impl<T: Clone+Slice<f64>> SubAssign<[<$quantity Slice>]<T>> for [<$quantity Slice>]<T>
+        {
+
+            fn sub_assign(&mut self, rhs: [<$quantity Slice>]<T>) {            
+                if rhs.values.len() != self.values.len()
+                {
+                    panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+                }
+                let factor = rhs.unit.convert_unchecked(self.unit).multiplier;
+                for (val, &rhs) in self.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+                {  
+                *val -= rhs*factor;
+                }
+            }
+        }
+
+        impl<T: Clone+Slice<f64>> crate::traits::FixedQuantity<[<$quantity Unit>]> for [<$quantity Slice>]<T>
+        {
+            fn unit(&self) -> [<$quantity Unit>] {
+                self.unit
+            }
+
+            fn convert(&self, unit: [<$quantity Unit>]) -> Self 
+            {
+                let mut result = self.clone();
+                result.convert_mut(unit);
+                return result;
+            }
+
+            fn convert_mut(&mut self, unit: [<$quantity Unit>]) {
+                let factor = self.unit.definition().convert_unchecked(unit.definition()).multiplier();
+                for val in self.values.as_mut_slice().iter_mut()
+                {
+                    *val *= factor;
+                }            
+            }
+        }
+    }
+    }
+}  
+#[macro_export]
 macro_rules! impl_quantity_ops {   
     ($quantity:ident) =>
     {
-        use core::ops::{Mul, Div, Add, Sub, AddAssign, SubAssign, MulAssign, DivAssign };
-        use $crate::quantity::IsQuantity;
-        impl IsQuantity for $quantity
-        {        
-            fn value(&self) -> f64 {
-                self.value
-            }
-        
-            fn definition(&self) -> UnitDefinition {
-                self.unit.into()
-            }
-        }
-        
         impl Mul<f64> for $quantity
         {
             type Output = $quantity;
@@ -105,21 +205,6 @@ macro_rules! impl_quantity_ops {
             }
         }
 
-        impl<T:IsQuantity> Mul<T> for $quantity
-        {
-            type Output = Quantity;
-            fn mul(self, rhs: T) -> Quantity {
-                Quantity{ value: self.value*rhs.value(), unit: self.definition()*rhs.definition() }
-            }
-        }
-        impl<T:IsQuantity> Div<T> for $quantity
-        {
-            type Output = Quantity;
-
-            fn div(self, rhs: T) -> Quantity {
-                Quantity{ value: self.value/rhs.value(), unit: self.definition()/rhs.definition() }
-            }
-        }
         impl Add<$quantity> for $quantity
         {
             type Output=Self;
@@ -231,7 +316,7 @@ macro_rules! quantity {
         #[allow(non_camel_case_types)]         
         #[allow(clippy::eq_op)]
         #[cfg_attr(feature="utoipa", derive(ToSchema))]        
-        #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity UnitI>]))]
+        #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity Unit>]))]
         pub enum [<$quantity Unit>]
         {
             $($unit,)+
@@ -240,30 +325,9 @@ macro_rules! quantity {
         paste::paste! { 
             pub(crate) const [<$quantity:upper _UNIT_BASE>]: UnitBase = crate::units_base::UOMDimensions::to_unit_base(($($crate::units_base::UOMDimensions::$dimension,)+));
             $(pub(crate) const [<$quantity:upper _ $unit:upper _conversion:upper>]: f64 = $conversion;)+
+        
         impl [<$quantity Unit>] 
         {
-            
-            /// get the UnitBase for this type of unit
-            pub(crate) const fn unit_base() -> UnitBase
-            {
-                [<$quantity:upper _UNIT_BASE>]
-            }
-
-            /// Retrieve the underlying `UnitDefinition`
-            pub const fn unit(&self) -> UnitDefinition
-            {
-                match self
-                {
-                    $([<$quantity Unit>]::$unit => UnitDefinition 
-                        { 
-                            multiplier: [<$quantity:upper _ $unit:upper _conversion:upper>], 
-                            base: [<$quantity Unit>]::unit_base()
-                        },
-                    )+
-                }
-                
-            }
-
             /// Get the base unit for this unit type (for length, as an example, this would be `meter`)
             pub fn base(&self) -> [<$quantity Unit>]
             {
@@ -275,7 +339,7 @@ macro_rules! quantity {
                 #[allow(clippy::eq_op)]
                 pub fn [<get_$unit:snake>]() -> UnitDefinition
                 {
-                    UnitDefinition{ base: [<$quantity Unit>]::unit_base(), multiplier: [<$quantity:upper _ $unit:upper _conversion:upper>] }
+                    UnitDefinition{ base: [<$quantity:upper _UNIT_BASE>], multiplier: [<$quantity:upper _ $unit:upper _conversion:upper>] }
                 })+
             }        
             #[doc = "Multiplier of unit to its base quantity."]
@@ -316,9 +380,23 @@ macro_rules! quantity {
             {
                 const UNITS: &[&'static str] = &[ $($singular,)+ ];                
                 UNITS
-            }
-            
+            }            
         }
+        impl $crate::traits::Unit for [<$quantity Unit>] 
+        {
+              /// Return unit definition for this Unit Type
+                fn definition(&self) -> UnitDefinition
+                {
+                    match self
+                    {                    
+                        $([<$quantity Unit>]::$unit=>[<$quantity Unit>]::[<get_$unit:snake>](),)+
+                    }
+                }
+                fn base(&self) -> UnitBase
+                {
+                    [<$quantity:upper _UNIT_BASE>]
+                }                
+            }        
         }
         paste::paste!
         {
@@ -364,16 +442,19 @@ macro_rules! quantity {
         
         paste::paste!
         {
+            use $crate::traits::FixedQuantity;
             $(#[$quantity_attr])*
             #[derive(Copy, Clone, Debug)]
             #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
             #[cfg_attr(feature="utoipa", derive(ToSchema))]
-            #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity I>]))]
+            #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity>]))]
+            #[doc = "Scalar storage of a quantity (f64 and [`" [<$quantity Unit>]"`])."]   
             pub struct $quantity
             {
                 pub value: f64,
                 pub unit: [<$quantity Unit>]   
             }
+          
             impl $quantity
             {
                 #[doc = "Create a new [`" [<$quantity Unit>]"`]."]   
@@ -436,6 +517,25 @@ macro_rules! quantity {
                     Ok(self.convert(destination_unit))                    
                 }                
             }
+            impl FixedQuantity<[<$quantity Unit>]> for $quantity
+            {                
+                fn unit(&self) -> [<$quantity Unit>]
+                {
+                    self.unit
+                }
+                /// Convert from this unit to another (creates a copy). No validation of base unit is made.
+                fn convert(&self, unit: [<$quantity Unit>]) -> Self
+                {
+                    Self { value: self.convert_unchecked(unit.into()), unit: unit }
+                }
+                /// Convert from this unit to another (modifies current quantity). No validation of base unit is made.
+                fn convert_mut(&mut self, unit: [<$quantity Unit>])
+                {
+                    self.value = self.convert_unchecked(unit.into());
+                }
+            }
+
+            
             
             impl From<$quantity> for UnitDefinition
             {
@@ -462,8 +562,48 @@ macro_rules! quantity {
                     $quantity { value: quantity.value, unit: [<$quantity Unit>]::try_from(quantity.unit).unwrap() }
                 } 
             }
-            use crate::impl_quantity_ops;
+            use crate::impl_quantity_ops;            
+            
+            #[derive(Clone, Debug)]
+            #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature="utoipa", derive(ToSchema))]            
+            #[cfg_attr(feature="utoipa", aliases([<$quantity Vec>]=[<$quantity Slice>]<Vec<f64>>))]
+            #[doc = "Array storage (must implement `Slice`) for a series of values and [`" [<$quantity Unit>]"`]. Utoipa alias has been implemented for `Vec<f64>`."]   
+            pub struct [<$quantity Slice>]<T: Clone+Slice<f64>>
+            {
+                pub unit: [<$quantity Unit>],
+                pub values: T
+            }
+            use crate::impl_quantity_slice;
+            impl<T: Clone+Slice<f64>> [<$quantity Slice>]<T>
+            {
+                #[doc = "Create a new vector of [`" [<$quantity Unit>]"`]."]   
+                pub fn new(values: T, unit: [<$quantity Unit>]) -> Self
+                {
+                    Self{values, unit}
+                }
+                $(
+                    #[doc = "Create a new [`" [<$quantity>] "`] with units of [`" [<$quantity Unit>] "::" [<$unit>] "`]."] 
+                    pub fn [<$unit:snake>](values: T) -> Self
+                    {
+                        Self{ values, unit: [<$quantity Unit>]::$unit.into() }
+                    }
+                )+
+                $(
+                    #[doc = "Convert to [`" [<$quantity Unit>] "::" [<$unit>] "`]."]                        
+                    #[inline]
+                    pub fn [<to_ $unit:snake>](&self) -> Self
+                    {                     
+                        let mut r = self.clone();
+                        r.convert_mut([<$quantity Unit>]::$unit);
+                        r
+                    }
+                )+
+            }
+
             impl_quantity_ops!($quantity);
+            impl_quantity_slice!($quantity);
+
         }        
         paste::paste!
         {
@@ -560,9 +700,13 @@ macro_rules! system {
            paste::paste!{#[cfg(any(feature = "" $quantity, feature="All"))]
            mod [<$quantity:snake>];
             }
-           paste::paste!{#[cfg(any(feature = "" $quantity, feature="All"))]           
-           pub use $crate::unit_definitions::[<$quantity:snake>]::$quantity;      
-            }
+           paste::paste!{#[cfg(any(feature = "" $quantity, feature="All"))]       
+           pub use $crate::unit_definitions::[<$quantity:snake>]::[<$quantity Slice>];}          
+           paste::paste!{#[cfg(any(feature = "" $quantity, feature="All"))]       
+           pub use $crate::unit_definitions::[<$quantity:snake>]::$quantity;}
+           #[cfg(any(feature = "" $quantity, feature="All"))]                                             
+           #[cfg(feature="utoipa")]
+           pub use $crate::unit_definitions::[<$quantity:snake>]::[<$quantity Vec>];
            
         )+
         pub mod quantities
@@ -571,7 +715,7 @@ macro_rules! system {
                 paste::paste!{
                     #[allow(clippy::eq_op)]
                     #[cfg(any(feature = "" $quantity, feature="All"))]                    
-                    pub use $crate::unit_definitions::[<$quantity:snake>]::$quantity;           
+                    pub use $crate::unit_definitions::[<$quantity:snake>]::$quantity;                         
                 }
             )+
             pub use $crate::quantity::Quantity;
@@ -722,7 +866,7 @@ macro_rules! system {
                     {
                         $(
                             #[cfg(any(feature = "" $quantity, feature="All"))]   
-                            Quantities::$quantity(x)=>Quantity { value: x.value, unit: UnitDefinition{multiplier: x.unit.multiplier(), base: [<$quantity:snake>]::[<$quantity Unit>]::unit_base()} },
+                            Quantities::$quantity(x)=>Quantity { value: x.value, unit: UnitDefinition{multiplier: x.unit.multiplier(), base: [<$quantity:snake>]::[<$quantity:upper _UNIT_BASE>]} },
                         )+
                     }
                 }
@@ -766,7 +910,7 @@ macro_rules! system {
                         {
                             $(
                                 #[cfg(any(feature = "" $quantity, feature="All"))]     
-                                Units::$quantity(x)=> UnitDefinition{multiplier: x.multiplier(), base: [<$quantity:snake>]::[<$quantity Unit>]::unit_base()},
+                                Units::$quantity(x)=> UnitDefinition{multiplier: x.multiplier(), base: [<$quantity:snake>]::[<$quantity:upper _UNIT_BASE>]},
                             )+
                         }
                     }
@@ -797,19 +941,7 @@ macro_rules! system {
                     $crate::quantity::Quantity { unit, value }
                 }
                 paste!{
-
-                ///
-                /// Get the base unit for this particular unit type (e.g. `LengthUnit` this would be `LengthUnit::meter`)
-                /// 
-                pub fn base(&self) -> Units
-                {
-                    match *self
-                    {
-                        $(
-                            #[cfg(any(feature = "" $quantity, feature="All"))]  
-                            Units::$quantity(x)=>Units::$quantity(x.base()),)+
-                    }
-                }     
+     
                 ///
                 /// Get list of units available for this `Units` type
                 /// 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -231,6 +231,7 @@ macro_rules! quantity {
         #[allow(non_camel_case_types)]         
         #[allow(clippy::eq_op)]
         #[cfg_attr(feature="utoipa", derive(ToSchema))]        
+        #[cfg_attr(feature="utoipa", schema(title = "" $quantity))]
         pub enum [<$quantity Unit>]
         {
             $($unit,)+
@@ -367,6 +368,7 @@ macro_rules! quantity {
             #[derive(Copy, Clone, Debug)]
             #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
             #[cfg_attr(feature="utoipa", derive(ToSchema))]
+            #[cfg_attr(feature="utoipa", schema(title = "" $quantity))]
             pub struct $quantity
             {
                 pub value: f64,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -603,7 +603,14 @@ macro_rules! quantity {
 
             impl_quantity_ops!($quantity);
             impl_quantity_slice!($quantity);
-
+            use crate::slice_quantity::SliceQuantity;
+            impl<T: Clone+Slice<f64>> From<[<$quantity Slice>]<T>> for SliceQuantity<T>
+            {
+                fn from(input: [<$quantity Slice>]<T>) -> Self 
+                {
+                    SliceQuantity{ unit: input.unit.definition(), values: input.values }
+                }
+            }
         }        
         paste::paste!
         {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -231,7 +231,7 @@ macro_rules! quantity {
         #[allow(non_camel_case_types)]         
         #[allow(clippy::eq_op)]
         #[cfg_attr(feature="utoipa", derive(ToSchema))]        
-        #[cfg_attr(feature="utoipa", schema(title = "" $quantity))]
+        #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity UnitI>]))]
         pub enum [<$quantity Unit>]
         {
             $($unit,)+
@@ -368,7 +368,7 @@ macro_rules! quantity {
             #[derive(Copy, Clone, Debug)]
             #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
             #[cfg_attr(feature="utoipa", derive(ToSchema))]
-            #[cfg_attr(feature="utoipa", schema(title = "" $quantity))]
+            #[cfg_attr(feature="utoipa", schema(title = "" [<$quantity I>]))]
             pub struct $quantity
             {
                 pub value: f64,

--- a/src/slice_quantity.rs
+++ b/src/slice_quantity.rs
@@ -1,6 +1,7 @@
-use crate::traits::{Slice, Unit};
+use crate::{errors::RuntimeUnitError, traits::Slice, units_base::UnitDefinition};
+use core::ops::{AddAssign, Div, DivAssign, Mul, MulAssign, SubAssign };
 
-// Implement slice trait for Vec and [f64;N]
+// Slice implementations for Vec and arrays.
 
 impl Slice<f64> for Vec<f64>
 {
@@ -30,3 +31,190 @@ impl<const SIZE: usize> Slice<f64> for [f64; SIZE]
         self.as_slice().len()
     }
 }
+
+
+#[derive(Clone)]
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
+#[doc ="Data structure to hold a unit and array of data"]
+pub struct SliceQuantity<T: Clone+Slice<f64>>
+{
+    pub unit: UnitDefinition,
+    pub values: T
+}
+
+// Defining Quantity for our SliceQuantity
+
+impl<T: Clone+Slice<f64>> crate::traits::Quantity for SliceQuantity<T>
+{
+    fn unit(&self) -> UnitDefinition {
+        self.unit
+    }
+
+    fn convert(&self, unit: UnitDefinition) -> Self 
+    {
+        let mut result = self.clone();
+        result.convert_mut(unit);
+        return result;
+    }
+
+    fn convert_mut(&mut self, unit: UnitDefinition) {
+        let factor = self.unit.convert_unchecked(unit).multiplier();
+        for val in self.values.as_mut_slice().iter_mut()
+        {
+            *val *= factor;
+        }            
+    }
+    
+    fn try_convert(&mut self, unit: UnitDefinition) -> Result<Self, crate::errors::RuntimeUnitError> {
+        if self.unit.base != unit.base
+        {
+            Err(RuntimeUnitError::IncompatibleUnitConversion(format!("Could not convert from base units of {} to {}", self.unit.unit_string(), unit.unit_string())))
+        }
+        else
+        {
+            Ok(self.convert(unit))
+        }
+
+    }
+    
+    fn try_convert_mut(&mut self, unit: UnitDefinition) -> Result<(), crate::errors::RuntimeUnitError> {
+        if self.unit.base != unit.base
+        {
+            Err(RuntimeUnitError::IncompatibleUnitConversion(format!("Could not convert from base units of {} to {}", self.unit.unit_string(), unit.unit_string())))
+        }
+        else
+        {
+            Ok(self.convert_mut(unit))
+        }
+    }
+}
+
+
+
+
+impl<T: Clone+Slice<f64>> Div<f64> for SliceQuantity<T>
+{
+    type Output = SliceQuantity<T>;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        let mut result = self.clone();
+        for val in result.values.as_mut_slice()
+        {  
+           *val /= rhs;
+        }
+        result
+    }
+}
+impl<T: Clone+Slice<f64>> Div<SliceQuantity<T>> for SliceQuantity<T>
+{
+    type Output = SliceQuantity<T>;
+
+    fn div(self, rhs: SliceQuantity<T>) -> Self::Output {
+        let mut result = self.clone();
+        if rhs.values.len() != self.values.len()
+        {
+            panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+        }
+        for (val, &rhs) in result.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+        {  
+           *val /= rhs;
+        }
+        result
+    }
+}
+impl<T: Clone+Slice<f64>> Mul<SliceQuantity<T>> for SliceQuantity<T>
+{
+    type Output = SliceQuantity<T>;
+
+    fn mul(self, rhs: SliceQuantity<T>) -> Self::Output {
+        let mut result = self.clone();
+        if rhs.values.len() != self.values.len()
+        {
+            panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+        }
+        for (val, &rhs) in result.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+        {  
+           *val *= rhs;
+        }
+        result
+    }
+}
+impl<T: Clone+Slice<f64>> Mul<f64> for SliceQuantity<T>
+{
+    type Output = SliceQuantity<T>;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        let mut result = self.clone();
+        for val in result.values.as_mut_slice()
+        {  
+           *val *= rhs;
+        }
+        result
+    }
+}
+impl<T: Clone+Slice<f64>> DivAssign<f64> for SliceQuantity<T>
+{
+
+    fn div_assign(&mut self, rhs: f64) {        
+        for val in self.values.as_mut_slice()
+        {  
+           *val /= rhs;
+        }
+    }
+}
+impl<T: Clone+Slice<f64>> MulAssign<f64> for SliceQuantity<T>
+{
+
+    fn mul_assign(&mut self, rhs: f64) {        
+        for val in self.values.as_mut_slice()
+        {  
+           *val *= rhs;
+        }
+    }
+}
+impl<T: Clone+Slice<f64>> DivAssign<SliceQuantity<T>> for SliceQuantity<T>
+{
+
+    fn div_assign(&mut self, rhs: SliceQuantity<T>) {            
+        if rhs.values.len() != self.values.len()
+        {
+            panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+        }
+        for (val, &rhs) in self.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+        {  
+           *val /= rhs;
+        }
+    }
+}
+impl<T: Clone+Slice<f64>> AddAssign<SliceQuantity<T>> for SliceQuantity<T>
+{
+
+    fn add_assign(&mut self, rhs: SliceQuantity<T>) {            
+        if rhs.values.len() != self.values.len()
+        {
+            panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+        }
+        let factor = rhs.unit.convert_unchecked(self.unit).multiplier;
+        for (val, &rhs) in self.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+        {  
+           *val += rhs*factor;
+        }
+    }
+}
+impl<T: Clone+Slice<f64>> SubAssign<SliceQuantity<T>> for SliceQuantity<T>
+{
+
+    fn sub_assign(&mut self, rhs: SliceQuantity<T>) {            
+        if rhs.values.len() != self.values.len()
+        {
+            panic!("Slice dimensions do not match: {} != {}", rhs.values.len(), self.values.len());
+        }
+        let factor = rhs.unit.convert_unchecked(self.unit).multiplier;
+        for (val, &rhs) in self.values.as_mut_slice().iter_mut().zip(rhs.values.as_slice())
+        {  
+           *val -= rhs*factor;
+        }
+    }
+}
+
+

--- a/src/slice_quantity.rs
+++ b/src/slice_quantity.rs
@@ -1,0 +1,32 @@
+use crate::traits::{Slice, Unit};
+
+// Implement slice trait for Vec and [f64;N]
+
+impl Slice<f64> for Vec<f64>
+{
+    fn as_mut_slice(&mut self) -> &mut [f64] {
+        self.as_mut_slice()
+    }
+
+    fn as_slice(&self) -> &[f64] {
+        self.as_slice()
+    }
+
+    fn len(&self) -> usize {
+       Vec::len(&self)
+    }
+}
+impl<const SIZE: usize> Slice<f64> for [f64; SIZE]
+{
+    fn as_mut_slice(&mut self) -> &mut [f64] {
+        self
+    }
+
+    fn as_slice(&self) -> &[f64] {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 mod test
-{   
+{
+
+    use crate::units::TimeUnit;
+    use crate::{units::LengthUnit, units_base::UnitDefinition};
+   
     #[test]
     #[cfg(all(any(feature="All", all(feature="Time", feature="Length", feature="Velocity", feature="Acceleration")), feature="std", feature="serde"))]
     fn test_unit_serialization()
@@ -178,5 +182,19 @@ mod test
     {
         use serde_json::json;
         println!("{}",json!(crate::Length::new(1.0, crate::units::LengthUnit::centimeter)));
+    }
+   
+    
+
+    #[test]
+    fn test_vector_quantity()
+    {
+        use crate::LengthSlice;
+        let length_meters = LengthSlice::meter(vec![1.0, 2.0, 3.0]);        
+        let length_centimeters = length_meters.to_centimeter();
+        for (&val_m, &val_cm) in length_meters.values.iter().zip(&length_centimeters.values)
+        {
+            assert_eq!(val_m*100.0, val_cm);
+        }        
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,68 @@
+use crate::{errors::RuntimeUnitError, units_base::{UnitBase, UnitDefinition}};
+use core::ops::{Mul, Div, AddAssign, SubAssign, MulAssign, DivAssign };
+
+///
+/// Trait that implements conversion of an arbitrary quantity into another
+/// 
+pub trait Quantity where Self: Sized + Div<f64> + Mul<f64> + DivAssign<f64> + MulAssign<f64> + Div<Self> + Mul<Self> + AddAssign<Self> + SubAssign<Self> + DivAssign<Self>
+{
+    /// Return unit associated with this quantity
+    fn unit(&self) -> UnitDefinition;
+    /// Try to convert from this unit to another (creates a copy)
+    fn try_convert(&mut self, unit: UnitDefinition) -> Result<Self, RuntimeUnitError>;
+    /// Try to convert from this unit to another (modifies current quantity)
+    fn try_convert_mut(&mut self, unit: UnitDefinition) -> Result<(), RuntimeUnitError>;    
+    /// Convert from this unit to another (creates a copy). No validation of base unit is made.
+    fn convert(&self, unit: UnitDefinition) -> Self;
+    /// Convert from this unit to another (modifies current quantity). No validation of base unit is made.
+    fn convert_mut(&mut self, unit: UnitDefinition);
+}
+
+///
+/// Trait that implements conversion of a quantity of a given unit type to another of the same type
+/// 
+pub trait FixedQuantity<UnitType: Unit> where Self: Sized + Div<f64> + Mul<f64> + DivAssign<f64> + MulAssign<f64> + AddAssign<Self> + SubAssign<Self> 
+{
+    /// Return unit associated with this quantity
+    fn unit(&self) -> UnitType;    
+    /// Convert from this unit to another (creates a copy). No validation of base unit is made.
+    fn convert(&self, unit: UnitType) -> Self;
+    /// Convert from this unit to another (modifies current quantity). No validation of base unit is made.
+    fn convert_mut(&mut self, unit: UnitType);
+}
+
+pub trait Slice<Element>
+{
+    fn as_mut_slice(&mut self) -> &mut [Element];
+    fn as_slice(&self) -> &[Element];
+    fn len(&self) -> usize;
+}
+
+pub trait Unit where Self:Sized
+{
+    /// Return unit definition for this Unit Type
+    fn definition(&self) -> UnitDefinition;
+
+    /// Base unit definition
+    fn base(&self) -> UnitBase;
+
+    /// Convert from this unit to another. No validation of base unit is made.
+    fn try_convert(&self, unit: UnitDefinition) -> Result<UnitDefinition, RuntimeUnitError>
+    {
+        let definition = self.definition();
+        if definition.is_convertible(unit)
+        {
+            Ok(UnitDefinition { base: definition.base, multiplier: unit.multiplier() / definition.multiplier() })
+        }
+        else
+        {
+            Err(RuntimeUnitError::IncompatibleUnitConversion(format!("Could not convert from base units of {} to {}", definition.unit_string(), unit.unit_string())))
+        }
+    }
+    /// Try converting from this unit to another.
+    fn convert_unchecked(&self, unit: Self) -> UnitDefinition
+    {
+        let definition = self.definition();
+        UnitDefinition { base: definition.base, multiplier: unit.definition().multiplier() / definition.multiplier() }
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,7 +19,7 @@ pub trait Quantity where Self: Sized + Div<f64> + Mul<f64> + DivAssign<f64> + Mu
 }
 
 ///
-/// Trait that implements conversion of a quantity of a given unit type to another of the same type
+/// Trait that implements conversion of a quantity within a given unit type (e.g. m->cm, kg->g)
 /// 
 pub trait FixedQuantity<UnitType: Unit> where Self: Sized + Div<f64> + Mul<f64> + DivAssign<f64> + MulAssign<f64> + AddAssign<Self> + SubAssign<Self> 
 {
@@ -31,6 +31,9 @@ pub trait FixedQuantity<UnitType: Unit> where Self: Sized + Div<f64> + Mul<f64> 
     fn convert_mut(&mut self, unit: UnitType);
 }
 
+///
+/// A trait to define storage that provides iterator over an `Element` of a given type.
+/// 
 pub trait Slice<Element>
 {
     fn as_mut_slice(&mut self) -> &mut [Element];
@@ -38,6 +41,10 @@ pub trait Slice<Element>
     fn len(&self) -> usize;
 }
 
+
+///
+/// Trait to define a type of unit (e.g. `LengthUnit`,`MassUnit`)
+/// 
 pub trait Unit where Self:Sized
 {
     /// Return unit definition for this Unit Type


### PR DESCRIPTION
This PR corrects several issues I've run into:

1. Added titles to units and quantities.
2. Added support for array-based quantities.